### PR TITLE
add fnProcessData hook to 'flickr' kind of galleries

### DIFF
--- a/src/jquery.nanogallery2.data_flickr.js
+++ b/src/jquery.nanogallery2.data_flickr.js
@@ -220,7 +220,8 @@
         tn=FlickrRetrieveImages(tn, item, 'l1' );
         tn=FlickrRetrieveImages(tn, item, 'lN' );
         newItem.thumbs=tn;
-
+	if (typeof G.O.fnProcessData == 'function')
+	  G.O.fnProcessData(newItem, 'flickr', source);
       });
       G.I[albumIdx].contentIsLoaded=true;
       


### PR DESCRIPTION
FIXME: more hooks may be missing

Personal note: I do not understand fully the mechanism of additional JS files - the gallery works even with just the main gallery JS file loaded into the HTML page, including loading images from Flickr. So feel free to modify my commit if you know a better solution. This works for me and looks using the same principle as 'gphoto' module does.

Milan