### PR TITLE
Enable the Use of Filename as a Title with Google Photos

### DIFF
--- a/src/jquery.nanogallery2.data_google3.js
+++ b/src/jquery.nanogallery2.data_google3.js
@@ -145,7 +145,12 @@
         var itemDescription = '';
 				var itemTitle = '';
         if( kind == 'image') {
-						itemTitle = data.description;
+            if (data.description !== undefined ){
+              itemDescription = data.description
+            }
+            if( G.O.thumbnailLabel.get('title') != '' ) {
+              itemTitle=GetImageTitleFromURL(data.filename);
+            }
         }
 				else {
 					itemTitle = data.title;


### PR DESCRIPTION
Enable the use of filename as the title with Google photos similar to Flickr.

Moves the description value to the proper location