### PR TITLE
fnGalleryRenderEnd not returning the correct albumID

### DIFF
--- a/src/jquery.nanogallery2.core.js
+++ b/src/jquery.nanogallery2.core.js
@@ -1976,7 +1976,7 @@
     // author: underscore.js - http://underscorejs.org/docs/underscore.html
     // Returns a function, that, when invoked, will only be triggered at most once during a given window of time.
     // Normally, the throttled function will run as much as it can, without ever going more than once per wait duration;
-    // but if youíd like to disable the execution on the leading edge, pass {leading: false}.
+    // but if you¬íd like to disable the execution on the leading edge, pass {leading: false}.
     // To disable execution on the trailing edge, ditto.
     var throttle = function(func, wait, options) {
       var context, args, result;
@@ -3497,7 +3497,7 @@
       TriggerCustomEvent('galleryRenderEnd');
       var fu=G.O.fnGalleryRenderEnd;
       if( fu !== null ) {
-        typeof fu == 'function' ? fu(albumIdx) : window[fu](albumIdx);
+        typeof fu == 'function' ? fu(G.I[G.GOM.albumIdx].GetID()) : window[fu](albumIdx);
       }
 
       // Step 1: populate GOM
@@ -7342,7 +7342,7 @@
         };
       }
 
-      // requestAnimationFrame polyfill by Erik Mˆller. fixes from Paul Irish and Tino Zijdel
+      // requestAnimationFrame polyfill by Erik M√∂ller. fixes from Paul Irish and Tino Zijdel
       // http://paulirish.com/2011/requestanimationframe-for-smart-animating/
       // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
       // MIT license
@@ -7841,7 +7841,7 @@
       var vimg = new VImg(ngy2ItemIdx);
       G.VOM.items.push(vimg);
       items.push(G.I[ngy2ItemIdx]);
-      //TODO -> danger? -> pourquoi reconstruire la liste si dÈj‡ ouvert (back/forward)     
+      //TODO -> danger? -> pourquoi reconstruire la liste si d√©j√† ouvert (back/forward)     
       var l = G.I.length;
       for( var idx = ngy2ItemIdx+1; idx < l ; idx++) {
         var item = G.I[idx];


### PR DESCRIPTION
It seems like it was returning the position of the album within the base album (ID : 0), instead of returning the actual albumID. This fixes it.

I'm not very used to GitHub, not so sure why there is so many false changes in my pull request... anyways, the only change is on line 3500 :

`typeof fu == 'function' ? fu(G.I[G.GOM.albumIdx].GetID()) : window[fu](albumIdx);`