### PR TITLE
Toolbars hiding improvements

### DIFF
--- a/src/jquery.nanogallery2.core.js
+++ b/src/jquery.nanogallery2.core.js
@@ -1501,7 +1501,8 @@ todo:
       align :                     'center',
       autoMinimize :              0,
       standard :                  'minimizeButton,label',
-      minimized :                 'minimizeButton,label,infoButton,shareButton,fullscreenButton'
+      minimized :                 'minimizeButton,label,infoButton,shareButton,fullscreenButton',
+      preventHidingCallback:      null
     },
     viewerTools : {
       topLeft :                   'pageCounter,playPauseButton',
@@ -9208,6 +9209,9 @@ debugger;
     function ViewerToolsHide() {
       if( G.VOM.viewerDisplayed ) {
         let elapsedSinceLastUnHide = G.VOM.lastUnhideTime ? Date.now()-G.VOM.lastUnhideTime : G.O.viewerHideToolsDelay;
+
+        if (G.O.viewerToolbar.preventHidingCallback && G.O.viewerToolbar.preventHidingCallback())
+          return Math.min(1000, G.O.viewerHideToolsDelay);
 
         if (elapsedSinceLastUnHide>=G.O.viewerHideToolsDelay) { // Hide
           G.VOM.toolbarsDisplayed = false;

--- a/src/jquery.nanogallery2.core.js
+++ b/src/jquery.nanogallery2.core.js
@@ -10534,7 +10534,7 @@ debugger;
       }
 			
       // lightbox: hide tools/gallery after defined delay
-      G.VOM.toolsHide = debounceMulti( ViewerToolsHide, G.O.viewerHideToolsDelay, false );
+      G.VOM.toolsHide = debounceMulti( ViewerToolsHide, G.O.viewerHideToolsDelay);
       
       // Keyboard management
       jQuery(document).keyup(function(e) {


### PR DESCRIPTION
This patch provides two functionalities intended to improve the hiding of the toolbars.
1) Until now, if the user keeps moving the mouse, the toolsbars where hidden and then shown again. This is not an expected behavior, as in general they should stay out until the user moves the mouse, and the hide. This is achieve with a new method, debounceMulti(), which can keep postponing the requested method call until required.
2) In addition, there can be cases where there is some external logic that should prevent the toolbars from hiding. My use case is adding a panel next to the right or left arrow; in this case, as long as the mouse is on the panel, I don't want the tollbars (and my panel!) to disappear.

Apart from the patch, please consider this two issues:
1) This page does not work anymore:
https://nano.gallery/lic/lic.php

I would like to buy a license very soon, I am just waiting to incorporate a company.
2) jquery.nanogallery2.core.js has mixed line endings (on my computer with my settings, 183 lines end with "\n" while the rest use "\r\n"). This make it annoying to contribute a patch. If you can fix this issue, it would be good. 

And thank you for your work: nanogallery is great!