### PR TITLE
Fixed preloading of videos

### DIFF
--- a/src/jquery.nanogallery2.core.js
+++ b/src/jquery.nanogallery2.core.js
@@ -2097,7 +2097,7 @@
     // author: underscore.js - http://underscorejs.org/docs/underscore.html
     // Returns a function, that, when invoked, will only be triggered at most once during a given window of time.
     // Normally, the throttled function will run as much as it can, without ever going more than once per wait duration;
-    // but if youíd like to disable the execution on the leading edge, pass {leading: false}.
+    // but if you¬íd like to disable the execution on the leading edge, pass {leading: false}.
     // To disable execution on the trailing edge, ditto.
     var throttle = function(func, wait, options) {
       var context, args, result;
@@ -6194,7 +6194,7 @@
         markup: function( url ) {
           // return '<video controls class="nGY2ViewerMedia"><source src="${id.src}" type="video/${id.type}" preload="auto">Your browser does not support the video tag (HTML 5).</video>';
           var extension = url.split('.').pop();
-          return '<video controls class="nGY2ViewerMedia"><source src="'+ url +'" type="video/'+ extension +'" preload="auto">Your browser does not support the video tag (HTML 5).</video>';
+          return '<video controls class="nGY2ViewerMedia" preload="auto"><source src="'+ url +'" type="video/'+ extension +'">Your browser does not support the video tag (HTML 5).</video>';
         },
         kind: 'video',
         selfhosted : true
@@ -7888,7 +7888,7 @@
         };
       }
 
-      // requestAnimationFrame polyfill by Erik Mˆller. fixes from Paul Irish and Tino Zijdel
+      // requestAnimationFrame polyfill by Erik M√∂ller. fixes from Paul Irish and Tino Zijdel
       // http://paulirish.com/2011/requestanimationframe-for-smart-animating/
       // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
       // MIT license
@@ -8396,7 +8396,7 @@
       var vimg = new VImg(ngy2ItemIdx);
       G.VOM.items.push(vimg);
       items.push(G.I[ngy2ItemIdx]);
-      //TODO -> danger? -> pourquoi reconstruire la liste si dÈj‡ ouvert (back/forward)     
+      //TODO -> danger? -> pourquoi reconstruire la liste si d√©j√† ouvert (back/forward)     
       var l = G.I.length;
       for( let idx = ngy2ItemIdx+1; idx < l ; idx++) {
         let item = G.I[idx];


### PR DESCRIPTION
The `preload='auto'` attribute was previously in the `<source>` tag within the video markup, whereas it should belong to the `<video>` tag itself. This is now fixed.