### PR TITLE
Allow thumbnail navigation without zooming enabled

### DIFF
--- a/src/jquery.nanogallery2.core.js
+++ b/src/jquery.nanogallery2.core.js
@@ -8987,9 +8987,6 @@
         });
         
 				
-				// ZOOM FEATURE ENABLED
-        if( G.O.viewerZoom ) {
-
 					G.VOM.hammertime.add( new NGHammer.Tap({ event: 'doubletap', taps: 2, interval: 250 }) );
           G.VOM.hammertime.add( new NGHammer.Tap({ event: 'singletap' }) );
           G.VOM.hammertime.get('doubletap').recognizeWith('singletap');
@@ -9081,6 +9078,8 @@
             }
           });
           
+        // ZOOM FEATURE ENABLED
+        if( G.O.viewerZoom ) {
           // double tap -> zoom
           G.VOM.hammertime.on('doubletap', function(ev) {
             if( !ViewerEvents() ) { return; }


### PR DESCRIPTION
I noticed that when I set `"viewerZoom": false` clicking on the thumbnails along the bottom when viewing an image stopped being able to be clicked to navigate to other images. It looks like this is because those events aren't registered except for when zooming is enabled. 

This PR moves the `if` clause slightly to always allow thumbnail navigation even when viewer zoom is set to false.