### PR TITLE
Add description as alt text in viewer mode

### DIFF
--- a/src/jquery.nanogallery2.core.js
+++ b/src/jquery.nanogallery2.core.js
@@ -914,8 +914,9 @@
           NGY2Item.prototype.setMediaURL = function( url, mediaKind ) {
             this.src = url;
             this.mediaKind = mediaKind;
+            var alt_text = this.description;
             if( mediaKind == 'img' ) {
-              this.mediaMarkup = '<img class="nGY2ViewerMedia" src="' + url + '" alt=" " itemprop="contentURL" draggable="false">';
+              this.mediaMarkup = '<img class="nGY2ViewerMedia" src="' + url + '" alt="' + alt_text + '" itemprop="contentURL" draggable="false">';
             }
           };
           


### PR DESCRIPTION
This adds the content from the description of the image to the alt tag when in viewer mode.