### PR TITLE
Support for array of tags (instead string split)

### DIFF
--- a/src/jquery.nanogallery2.core.js
+++ b/src/jquery.nanogallery2.core.js
@@ -2101,7 +2101,7 @@
     // author: underscore.js - http://underscorejs.org/docs/underscore.html
     // Returns a function, that, when invoked, will only be triggered at most once during a given window of time.
     // Normally, the throttled function will run as much as it can, without ever going more than once per wait duration;
-    // but if you�d like to disable the execution on the leading edge, pass {leading: false}.
+    // but if youd like to disable the execution on the leading edge, pass {leading: false}.
     // To disable execution on the trailing edge, ditto.
     var throttle = function(func, wait, options) {
       var context, args, result;
@@ -7892,7 +7892,7 @@
         };
       }
 
-      // requestAnimationFrame polyfill by Erik M�ller. fixes from Paul Irish and Tino Zijdel
+      // requestAnimationFrame polyfill by Erik Möller. fixes from Paul Irish and Tino Zijdel
       // http://paulirish.com/2011/requestanimationframe-for-smart-animating/
       // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
       // MIT license
@@ -8400,7 +8400,7 @@
       var vimg = new VImg(ngy2ItemIdx);
       G.VOM.items.push(vimg);
       items.push(G.I[ngy2ItemIdx]);
-      //TODO -> danger? -> pourquoi reconstruire la liste si d�j� ouvert (back/forward)     
+      //TODO -> danger? -> pourquoi reconstruire la liste si déjà ouvert (back/forward)     
       var l = G.I.length;
       for( let idx = ngy2ItemIdx+1; idx < l ; idx++) {
         let item = G.I[idx];

--- a/src/jquery.nanogallery2.core.js
+++ b/src/jquery.nanogallery2.core.js
@@ -600,7 +600,11 @@
                 else {
                   if( tags != '' && tags != undefined ) {
                     // use set tags
-                    item.setTags(tags.split(' '));
+                    if (Array.isArray(tags)) {
+                        item.setTags(tags);
+                    } else {
+                        item.setTags(tags.split(' '));
+                    }
                   }
                 }
               // }
@@ -2097,7 +2101,7 @@
     // author: underscore.js - http://underscorejs.org/docs/underscore.html
     // Returns a function, that, when invoked, will only be triggered at most once during a given window of time.
     // Normally, the throttled function will run as much as it can, without ever going more than once per wait duration;
-    // but if you’d like to disable the execution on the leading edge, pass {leading: false}.
+    // but if youï¿½d like to disable the execution on the leading edge, pass {leading: false}.
     // To disable execution on the trailing edge, ditto.
     var throttle = function(func, wait, options) {
       var context, args, result;
@@ -7888,7 +7892,7 @@
         };
       }
 
-      // requestAnimationFrame polyfill by Erik Möller. fixes from Paul Irish and Tino Zijdel
+      // requestAnimationFrame polyfill by Erik Mï¿½ller. fixes from Paul Irish and Tino Zijdel
       // http://paulirish.com/2011/requestanimationframe-for-smart-animating/
       // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
       // MIT license
@@ -8396,7 +8400,7 @@
       var vimg = new VImg(ngy2ItemIdx);
       G.VOM.items.push(vimg);
       items.push(G.I[ngy2ItemIdx]);
-      //TODO -> danger? -> pourquoi reconstruire la liste si déjà ouvert (back/forward)     
+      //TODO -> danger? -> pourquoi reconstruire la liste si dï¿½jï¿½ ouvert (back/forward)     
       var l = G.I.length;
       for( let idx = ngy2ItemIdx+1; idx < l ; idx++) {
         let item = G.I[idx];


### PR DESCRIPTION
After change we can use array in JavaScript code (which allow us to use spece in tag names), for example:

```js
jQuery("#nanogallery2").nanogallery2( {
    // ### gallery settings ### 
    thumbnailHeight:  150,
    thumbnailWidth:   150,
    itemsBaseURL:     'https://nanogallery2.nanostudio.org/samples/',
    
    // ### gallery content ### 
    items: [
        { src: 'berlin1.jpg', srct: 'berlin1_t.jpg', title: 'Berlin 1', tags: ['Berlin', 'Black & White'] },
        { src: 'berlin2.jpg', srct: 'berlin2_t.jpg', title: 'Berlin 2', tags: ['Berlin', 'Color'] },
        { src: 'berlin3.jpg', srct: 'berlin3_t.jpg', title: 'Berlin 3', tags: ['Berlin', 'Black & White'] }
      ]
  });
});
```